### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"
   },
+  "resolutions": {
+    "react-error-overlay": "6.0.9"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "CI=false && react-scripts build",


### PR DESCRIPTION
Within yarn.lock the react-error-overlay resolves to version 6.0.11 producing a "Uncaught ReferenceError: process is not defined" when the user installs the dependency's